### PR TITLE
Persist cache when app closes

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -8,15 +8,32 @@ import TopMoviesScreen from "./screens/TopMovies";
 import SearchMoviesScreen from "./screens/SearchMovies";
 import { useSession } from "./hooks/useSession";
 import { useReactQueryDevTools } from "@dev-plugins/react-query";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { persistQueryClient } from "@tanstack/react-query-persist-client";
+import { createAsyncStoragePersister } from "@tanstack/query-async-storage-persister";
+import useNetworkDetection from "./hooks/useNetworkDetection";
 import AuthGuard from "./screens/AuthGuard";
+import NetworkStatusModal from "./components/NetworkStatusModal";
 
 const Tab = createBottomTabNavigator();
 const queryClient = new QueryClient();
+
+const asyncStoragePersistor = createAsyncStoragePersister({
+  storage: AsyncStorage,
+});
+
+persistQueryClient({
+  queryClient,
+  persister: asyncStoragePersistor,
+  maxAge: 1000 * 60 * 60 * 24,
+});
 
 export default function App() {
   const { session } = useSession();
 
   useReactQueryDevTools(queryClient);
+
+  const { modalVisible, setModalVisible, message } = useNetworkDetection();
 
   // Not using Expo Router (opinion: prefer file based to file system based routing)
   return (
@@ -31,6 +48,9 @@ export default function App() {
                   name="Search Movies"
                   component={SearchMoviesScreen}
                 />
+                <Tab.Screen name="My Movies">
+                  {() => <>My playlists</>}
+                </Tab.Screen>
                 <Tab.Screen name="Account">
                   {() => <Account session={session} />}
                 </Tab.Screen>
@@ -38,6 +58,11 @@ export default function App() {
             ) : (
               <Auth />
             )}
+            <NetworkStatusModal
+              isVisible={modalVisible}
+              message={message}
+              onClose={() => setModalVisible(false)}
+            />
           </View>
         </AuthGuard>
       </NavigationContainer>

--- a/components/NetworkStatusModal.tsx
+++ b/components/NetworkStatusModal.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { Modal, View, Text, Button, StyleSheet } from "react-native";
+import { NetworkStatusModalProps } from "../types/Network";
+
+export default function NetworkStatusModal({
+  isVisible,
+  message,
+  onClose,
+}: NetworkStatusModalProps) {
+  return (
+    <Modal
+      transparent={true}
+      visible={isVisible}
+      animationType="fade"
+      onRequestClose={onClose}
+    >
+      <View style={styles.modalBackground}>
+        <View style={styles.modal}>
+          <Text>{message}</Text>
+          <Button title="Close" onPress={onClose} />
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  modalBackground: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    backgroundColor: "rgba(0,0,0,0.5)",
+  },
+  modal: {
+    width: 300,
+    padding: 20,
+    backgroundColor: "white",
+    borderRadius: 10,
+    gap: 8,
+  },
+});

--- a/constants/query.ts
+++ b/constants/query.ts
@@ -2,3 +2,8 @@ export enum Queries {
   TOP_MOVIES = "Top Movies",
   SEARCH_MOVIES = "Search Movies",
 }
+
+export enum QueryPersistanceKeys {
+  LAST_QUERY = "lastSearchQuery",
+  LAST_PAGE = "lastPage",
+}

--- a/hooks/useMovieSearch.ts
+++ b/hooks/useMovieSearch.ts
@@ -54,6 +54,7 @@ export const useMovieSearch = (query: string, currentPage: number) => {
     },
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
-    staleTime: Infinity,
+    staleTime: 1000 * 60 * 5, // Does regular (5mins) refetching online
+    gcTime: Infinity, // No garbage collection to keep stale cache
   });
 };

--- a/hooks/useMovieSearch.ts
+++ b/hooks/useMovieSearch.ts
@@ -39,14 +39,14 @@ const fetchMovies = async ({
   };
 };
 
-export const useMovieSearch = (query: string) => {
+export const useMovieSearch = (query: string, currentPage: number) => {
   const trimmedQuery = query.trim();
 
   return useInfiniteQuery({
     queryKey: [Queries.SEARCH_MOVIES, trimmedQuery],
     queryFn: fetchMovies,
     enabled: !!trimmedQuery,
-    initialPageParam: 1,
+    initialPageParam: currentPage,
     getNextPageParam: (lastPage) => {
       return lastPage.nextPage <= lastPage.totalPages
         ? lastPage.nextPage
@@ -54,6 +54,6 @@ export const useMovieSearch = (query: string) => {
     },
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
-    staleTime: 1000 * 60 * 5,
+    staleTime: Infinity,
   });
 };

--- a/hooks/useNetworkDetection.ts
+++ b/hooks/useNetworkDetection.ts
@@ -1,13 +1,53 @@
-import { useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import NetInfo from "@react-native-community/netinfo";
 import { onlineManager } from "@tanstack/react-query";
 
 export default function useNetworkDetection() {
+  const [modalVisible, setModalVisible] = useState(false);
+  const [message, setMessage] = useState("");
+
+  // Track initial connection state to avoid showing modal on app launch
+  const hasCheckedInitialConnection = useRef<boolean>(false);
+  const lastConnectionState = useRef<boolean | null>(null); // Track the previous connection state to detect changes
+
+  const handleMessage = (isConnected: boolean) => {
+    onlineManager.setOnline(isConnected);
+    setMessage(isConnected ? "You are back online!" : "You are offline!");
+    setModalVisible(true);
+  };
+
+  const checkInitialConnection = async () => {
+    const state = await NetInfo.fetch();
+    const isConnected = !!state.isConnected;
+
+    hasCheckedInitialConnection.current = true;
+    lastConnectionState.current = isConnected;
+
+    if (!isConnected) {
+      handleMessage(false);
+    }
+  };
+
   useEffect(() => {
+    checkInitialConnection();
+
     const unsubscribe = NetInfo.addEventListener((state) => {
-      onlineManager.setOnline(!!state.isConnected);
+      const isConnected = !!state.isConnected;
+      if (
+        hasCheckedInitialConnection.current &&
+        lastConnectionState.current !== isConnected
+      ) {
+        handleMessage(isConnected);
+        lastConnectionState.current = isConnected;
+      }
     });
 
     return () => unsubscribe();
   }, []);
+
+  return {
+    modalVisible,
+    setModalVisible,
+    message,
+  };
 }

--- a/hooks/useNetworkDetection.ts
+++ b/hooks/useNetworkDetection.ts
@@ -1,22 +1,22 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import NetInfo from "@react-native-community/netinfo";
 import { onlineManager } from "@tanstack/react-query";
 
 export default function useNetworkDetection() {
-  const [modalVisible, setModalVisible] = useState(false);
-  const [message, setMessage] = useState("");
+  const [modalVisible, setModalVisible] = useState(<boolean>false);
+  const [message, setMessage] = useState<string>("");
 
   // Track initial connection state to avoid showing modal on app launch
   const hasCheckedInitialConnection = useRef<boolean>(false);
   const lastConnectionState = useRef<boolean | null>(null); // Track the previous connection state to detect changes
 
-  const handleMessage = (isConnected: boolean) => {
+  const handleMessage = useCallback((isConnected: boolean) => {
     onlineManager.setOnline(isConnected);
     setMessage(isConnected ? "You are back online!" : "You are offline!");
     setModalVisible(true);
-  };
+  }, []);
 
-  const checkInitialConnection = async () => {
+  const checkInitialConnection = useCallback(async () => {
     const state = await NetInfo.fetch();
     const isConnected = !!state.isConnected;
 
@@ -26,7 +26,7 @@ export default function useNetworkDetection() {
     if (!isConnected) {
       handleMessage(false);
     }
-  };
+  }, [handleMessage]);
 
   useEffect(() => {
     checkInitialConnection();
@@ -43,7 +43,7 @@ export default function useNetworkDetection() {
     });
 
     return () => unsubscribe();
-  }, []);
+  }, [checkInitialConnection, handleMessage]);
 
   return {
     modalVisible,

--- a/hooks/usePersistentSearch.ts
+++ b/hooks/usePersistentSearch.ts
@@ -1,0 +1,55 @@
+import { useState, useEffect } from "react";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { useQueryClient } from "@tanstack/react-query";
+import { Queries, QueryPersistanceKeys } from "../constants/query";
+import { MovieSearchQueryData } from "../types/Movie";
+
+export const usePersistentSearch = () => {
+  const queryClient = useQueryClient();
+  const [query, setQuery] = useState<string>("");
+  const [currentPage, setCurrentPage] = useState<number>(1);
+
+  useEffect(() => {
+    loadLastSearchData();
+  }, []);
+
+  useEffect(() => {
+    if (query) {
+      AsyncStorage.setItem(QueryPersistanceKeys.LAST_QUERY, query);
+    }
+    AsyncStorage.setItem(
+      QueryPersistanceKeys.LAST_PAGE,
+      currentPage.toString()
+    );
+  }, [query, currentPage]);
+
+  const loadLastSearchData = async () => {
+    const storedQuery = await AsyncStorage.getItem(
+      QueryPersistanceKeys.LAST_QUERY
+    );
+    const storedPage = await AsyncStorage.getItem(
+      QueryPersistanceKeys.LAST_PAGE
+    );
+
+    if (storedQuery) {
+      setQuery(storedQuery);
+    }
+    if (storedPage) {
+      setCurrentPage(Number(storedPage));
+    }
+
+    const cachedQueryData = queryClient.getQueryData<MovieSearchQueryData>([
+      Queries.SEARCH_MOVIES,
+      storedQuery,
+    ]);
+
+    if (cachedQueryData) {
+      console.log(
+        "Cached movies found:",
+        cachedQueryData.pages.flatMap((page) => page.movies)
+      );
+    }
+  };
+
+  return { query, setQuery, currentPage, setCurrentPage };
+};

--- a/hooks/usePersistentSearch.ts
+++ b/hooks/usePersistentSearch.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { QueryPersistanceKeys } from "../constants/query";
 
@@ -6,21 +6,7 @@ export const usePersistentSearch = () => {
   const [query, setQuery] = useState<string>("");
   const [currentPage, setCurrentPage] = useState<number>(1);
 
-  useEffect(() => {
-    loadLastSearchData();
-  }, []);
-
-  useEffect(() => {
-    if (query) {
-      AsyncStorage.setItem(QueryPersistanceKeys.LAST_QUERY, query);
-    }
-    AsyncStorage.setItem(
-      QueryPersistanceKeys.LAST_PAGE,
-      currentPage.toString()
-    );
-  }, [query, currentPage]);
-
-  const loadLastSearchData = async () => {
+  const loadLastSearchData = useCallback(async () => {
     const storedQuery = await AsyncStorage.getItem(
       QueryPersistanceKeys.LAST_QUERY
     );
@@ -34,7 +20,21 @@ export const usePersistentSearch = () => {
     if (storedPage) {
       setCurrentPage(Number(storedPage));
     }
-  };
+  }, []);
+
+  useEffect(() => {
+    loadLastSearchData();
+  }, [loadLastSearchData]);
+
+  useEffect(() => {
+    if (query) {
+      AsyncStorage.setItem(QueryPersistanceKeys.LAST_QUERY, query);
+    }
+    AsyncStorage.setItem(
+      QueryPersistanceKeys.LAST_PAGE,
+      currentPage.toString()
+    );
+  }, [query, currentPage]);
 
   return { query, setQuery, currentPage, setCurrentPage };
 };

--- a/hooks/usePersistentSearch.ts
+++ b/hooks/usePersistentSearch.ts
@@ -1,11 +1,8 @@
 import { useState, useEffect } from "react";
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import { useQueryClient } from "@tanstack/react-query";
-import { Queries, QueryPersistanceKeys } from "../constants/query";
-import { MovieSearchQueryData } from "../types/Movie";
+import { QueryPersistanceKeys } from "../constants/query";
 
 export const usePersistentSearch = () => {
-  const queryClient = useQueryClient();
   const [query, setQuery] = useState<string>("");
   const [currentPage, setCurrentPage] = useState<number>(1);
 
@@ -36,18 +33,6 @@ export const usePersistentSearch = () => {
     }
     if (storedPage) {
       setCurrentPage(Number(storedPage));
-    }
-
-    const cachedQueryData = queryClient.getQueryData<MovieSearchQueryData>([
-      Queries.SEARCH_MOVIES,
-      storedQuery,
-    ]);
-
-    if (cachedQueryData) {
-      console.log(
-        "Cached movies found:",
-        cachedQueryData.pages.flatMap((page) => page.movies)
-      );
     }
   };
 

--- a/screens/SearchMovies.tsx
+++ b/screens/SearchMovies.tsx
@@ -1,12 +1,13 @@
-import React, { useState } from "react";
 import { View, Text, ActivityIndicator, StyleSheet } from "react-native";
 import { useDebounce } from "../hooks/useDebounce";
 import { useMovieSearch } from "../hooks/useMovieSearch";
 import SearchBar from "../components/SearchBar";
 import MovieGrid from "../components/MovieGrid";
+import { usePersistentSearch } from "../hooks/usePersistentSearch";
 
 export default function SearchMoviesScreen() {
-  const [query, setQuery] = useState<string>("");
+  const { query, setQuery, currentPage, setCurrentPage } =
+    usePersistentSearch();
   const debouncedQuery = useDebounce(query, 500);
   const {
     data,
@@ -15,10 +16,13 @@ export default function SearchMoviesScreen() {
     isFetchingNextPage,
     isLoading,
     error,
-  } = useMovieSearch(debouncedQuery);
+  } = useMovieSearch(debouncedQuery, currentPage);
 
   const loadMore = () => {
-    if (hasNextPage && !isFetchingNextPage) fetchNextPage();
+    if (hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+      setCurrentPage((prevPage) => prevPage + 1);
+    }
   };
 
   const movies = data?.pages.flatMap((page) => page.movies) ?? [];
@@ -26,13 +30,13 @@ export default function SearchMoviesScreen() {
   return (
     <View style={styles.container}>
       <SearchBar query={query} onChangeQuery={setQuery} />
-      {isLoading && <ActivityIndicator size="large" />}
-      {!isLoading && debouncedQuery === "" && (
+      {isLoading ? <ActivityIndicator size="large" /> : null}
+      {!isLoading && debouncedQuery === "" ? (
         <Text style={styles.infoText}>Enter a movie name to search</Text>
-      )}
-      {!isLoading && debouncedQuery !== "" && movies.length === 0 && (
+      ) : null}
+      {!isLoading && debouncedQuery !== "" && movies.length === 0 ? (
         <Text style={styles.infoText}>No movies found</Text>
-      )}
+      ) : null}
       <MovieGrid
         movies={movies}
         isLoading={isLoading}

--- a/types/Movie.ts
+++ b/types/Movie.ts
@@ -17,3 +17,10 @@ export type MovieGridProps = {
   onEndReachedThreshold?: number;
   isFetchingNextPage?: boolean;
 };
+
+export type MovieSearchQueryData = {
+  pages: {
+    query: string;
+    movies: Movie[];
+  }[];
+};

--- a/types/Network.ts
+++ b/types/Network.ts
@@ -1,0 +1,5 @@
+export type NetworkStatusModalProps = {
+  isVisible: boolean;
+  message: string;
+  onClose: () => void;
+};


### PR DESCRIPTION
- Part of investigating offline mode: when the app is closed, the next time it opens we're still able to see previously searched movies. These are persisted in cache (the movies, the last made query and the last accessed page).

- Adds a popup that shows up when network changes are detected (going from online to offline and vice versa, only after the initial app loading)